### PR TITLE
Change guilds endpoint response on empty

### DIFF
--- a/routes/guilds.js
+++ b/routes/guilds.js
@@ -8,7 +8,7 @@ module.exports = class extends Route {
 
 	get(request, response) {
 		const guilds = this.client.guilds;
-        if (!guilds) response.end('[]');
+        	if (!guilds) response.end('[]');
 		return response.end(JSON.stringify(guilds));
 	}
 

--- a/routes/guilds.js
+++ b/routes/guilds.js
@@ -8,7 +8,7 @@ module.exports = class extends Route {
 
 	get(request, response) {
 		const guilds = this.client.guilds;
-        if (!guilds) response.end('{}');
+        if (!guilds) response.end('[]');
 		return response.end(JSON.stringify(guilds));
 	}
 

--- a/routes/guilds.js
+++ b/routes/guilds.js
@@ -8,7 +8,7 @@ module.exports = class extends Route {
 
 	get(request, response) {
 		const guilds = this.client.guilds;
-        	if (!guilds) response.end('[]');
+		if (!guilds) response.end('[]');
 		return response.end(JSON.stringify(guilds));
 	}
 


### PR DESCRIPTION
An array makes much more sense I think since the output of `JSON.stringify(this.client.guilds)` is an array.

Pardon the multiple commits. Those are just indenation fixes lol