### PR TITLE
Start and end dates are now the correct dates

### DIFF
--- a/commands/Information/anime.js
+++ b/commands/Information/anime.js
@@ -83,8 +83,9 @@ module.exports = class extends Command {
             let data = JSON.parse(await response.text());
             let media = data.data.Media;
             if(media === null) return this.sendNotFoundEmbed(message, anime);
-            let startDate = new Date(media.startDate.year, media.startDate.month, media.startDate.day);
-            let endDate = new Date(media.endDate.year, media.endDate.month, media.endDate.day);
+            let startDate = new Date(media.startDate.year, media.startDate.month-1, media.startDate.day);
+            let endDate = new Date(media.endDate.year, media.endDate.month-1, media.endDate.day);
+            console.log(endDate)
             let embed = new MessageEmbed()
             .setThumbnail(media.coverImage.large)
             .setColor('#dd67ff')


### PR DESCRIPTION
Need to subtract one from the months, as Javascript months start at 0 and Anilist months start at 1.